### PR TITLE
Revert "Cleanup unique location creation code"

### DIFF
--- a/wsgi/openshift/services/views.py
+++ b/wsgi/openshift/services/views.py
@@ -28,7 +28,11 @@ def createLocation(ipAddress):
         Location should have IP as a unique field. Change the IP
         or you won't be able to add the test value more than once. """
     ipHash = hashlib.md5(ipAddress).hexdigest()
-    obj, created = Location.objects.get_or_create(ip=ipHash)
+    if len(Location.objects.all().filter(ip=ipHash)) == 0:
+        ''' check for the HASHED ip in the database. If it isn't present,
+            create a new entry with the NON-HASHED ip as an argument. '''
+        entity = Location()
+        entity.create(ip=ipAddress)
     return ipHash
 
 class LocationViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
This reverts commit e0d7a212a19e2d769f7d921a1dbbb22644c7ceec.

get_or_create() does not call a custom create() function. It was
used here to get a boolean value to test for a key's existence.

Finding a way to use get_or_create() while calling the overwritten
create function would allow this code to be written more cleanly.