### PR TITLE
Re enable CI against the main branch of the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,3 @@ jobs:
           wait_ms: 15000
           detect_merge_changes: false
           conflict_comment: ":wave: Hi, @${author},\n\nConflicts have been detected against the base branch. Please rebase your branch against the base branch."
-
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-          architecture: x64
-      - name: Checkout head
-        uses: actions/checkout@v5
-      - name: Install flake8
-        run: pip install flake8
-      - name: Run flake8
-        run: cd web && flake8
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces below updates to run GitHub Actions in this repository.

1. Run workflows against the main branch.
2. Remove Flake8 job since ruff-pre-commit is rleady there at [pre-commit](https://github.com/mantidproject/reports/blob/main/.pre-commit-config.yaml#L29)
3. Removes the webtests job that is not currently active.



