### PR TITLE
Add query endpoint for trusted users

### DIFF
--- a/blank.env
+++ b/blank.env
@@ -17,6 +17,9 @@ DB_PORT=5432
 SECRET_KEY=<Not Set>
 DB_USER=<Not Set>
 DB_PASS=<Not Set>
+DB_RO_USER=<Not Set>
+DB_RO_PASS=<Not Set>
+QUERY_SECRET_KEY=<Not Set>
 
 #Trusted origins for CSRF validation. For production usage only specify https://reports.mantidproject.org
 DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:8082,https://reports.a.staging-mantidproject.stfc.ac.uk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,6 @@ services:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
       POSTGRES_DB: ${DB_NAME}
-      DB_SERVICE: ${DB_SERVICE}
-      DB_PORT: ${DB_PORT}
-      SECRET_KEY: ${SECRET_KEY}
 
   adminer:
     image: adminer
@@ -34,12 +31,6 @@ services:
     depends_on:
       - postgres
     env_file: .env
-    environment:
-      DB_SERVICE: ${DB_SERVICE}
-      DB_PORT: ${DB_PORT}
-      SECRET_KEY: ${SECRET_KEY}
-      # Define this in .env for development mode. DO NOT USE IN PRODUCTION
-      DEBUG: ${DEBUG}
 
   nginx-reports:
     restart: always

--- a/nginx/confs/mantidreports.conf
+++ b/nginx/confs/mantidreports.conf
@@ -34,10 +34,7 @@ server {
 
     location /api/query {
         # allow ISIS VPN traffic
-        allow 130.246.180.13/32;
-        allow 130.246.180.101/32;
-        allow 130.246.186.163/32;
-        allow 130.246.223.126/32;
+        allow 130.246.0.0/16;
         deny  all;
 
         proxy_pass http://web:8000;

--- a/nginx/confs/mantidreports.conf
+++ b/nginx/confs/mantidreports.conf
@@ -32,6 +32,10 @@ server {
         proxy_read_timeout         60s;
     }
 
+    set_real_ip_from 172.0.17.0/24;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
     location /api/query {
         # allow ISIS VPN traffic
         allow 130.246.0.0/16;

--- a/nginx/confs/mantidreports.conf
+++ b/nginx/confs/mantidreports.conf
@@ -32,4 +32,22 @@ server {
         proxy_read_timeout         60s;
     }
 
+    location /api/query {
+        # allow ISIS VPN traffic
+        allow 130.246.180.13/32;
+        allow 130.246.180.101/32;
+        allow 130.246.186.163/32;
+        allow 130.246.223.126/32;
+        deny  all;
+
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout      60s;
+        proxy_send_timeout         60s;
+        proxy_read_timeout         60s;
+    }
 }

--- a/web/run_django.sh
+++ b/web/run_django.sh
@@ -8,7 +8,7 @@ python manage.py migrate --noinput
 
 # If running in DEBUG mode add debug logging to gunicorn
 if [ -n "${DEBUG}" ]; then
-  DEBUG_ARGS="--log-level debug --capture-output"
+  DEBUG_ARGS="--log-level debug --capture-output --reload"
 else
   DEBUG_ARGS=
 fi

--- a/web/services/urls.py
+++ b/web/services/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path("by/user", views.usage_by_users, name="by-users"),
     path("host", views.host_list, name="host-list"),
     path("user", views.user_list, name="user-list"),
+    path("query", views.query, name="query"),
     # url(r'feature', views.feature_usage, name='feature_usage'),
 ]
 

--- a/web/services/views.py
+++ b/web/services/views.py
@@ -22,7 +22,6 @@ import datetime
 import hashlib
 import services.plots as plotsfile
 from os import environ
-import re
 
 OS_NAMES = ["Linux", "Windows NT", "Darwin"]
 UTC = datetime.tzinfo("UTC")
@@ -331,6 +330,7 @@ def by_root(request, format=None):
         }
     )
 
+
 @api_view(("POST",))
 def query(request, format=None):
     if not verify_token(request):
@@ -338,11 +338,12 @@ def query(request, format=None):
     sql_err, sql = get_parameter(request, "sql")
     if sql_err:
         return response.Response(status=400, data=f"Invalid Parameters: {sql_err}")
-    conn=connections["readonly"]
+    conn = connections["readonly"]
     with conn.cursor() as cur:
         cur.execute(sql)
         res = cur.fetchall()
     return response.Response(res)
+
 
 def get_bearer_token(request):
     """
@@ -356,6 +357,7 @@ def get_bearer_token(request):
         return None
     return parts[1].strip() or None
 
+
 def get_parameter(request, param):
     val = request.POST.get(param)
     err = ""
@@ -363,10 +365,12 @@ def get_parameter(request, param):
         err = f"No {param} parameter provided"
     return err, val
 
+
 def verify_token(request) -> bool:
     token = get_bearer_token(request)
     secret = environ.get("QUERY_SECRET_KEY", "")
-    return token==secret
+    return token == secret
+
 
 class FeatureViewSet(viewsets.ModelViewSet):
     """

--- a/web/services/views.py
+++ b/web/services/views.py
@@ -346,7 +346,7 @@ def query(request, format=None):
     return response.Response(res)
 
 def get_parameter(request, param):
-    val = request.POST.get[param]
+    val = request.POST.get(param)
     err = ""
     if not val:
         err = f"No {param} parameter provided"

--- a/web/services/views.py
+++ b/web/services/views.py
@@ -22,6 +22,7 @@ import datetime
 import hashlib
 import services.plots as plotsfile
 from os import environ
+import re
 
 OS_NAMES = ["Linux", "Windows NT", "Darwin"]
 UTC = datetime.tzinfo("UTC")
@@ -332,18 +333,28 @@ def by_root(request, format=None):
 
 @api_view(("POST",))
 def query(request, format=None):
-    sql_err, sql = get_parameter(request, "sql")
-    token_err, token = get_parameter(request, "token")
-    if sql_err or token_err:
-        return response.Response(status=400, data=f"Invalid Parameters: {[x for x in [sql_err, token_err] if x]}")
-    verified = verify_token(token)
-    if not verified:
+    if not verify_token(request):
         return response.Response(status=401, data="UNAUTHORIZED")
+    sql_err, sql = get_parameter(request, "sql")
+    if sql_err:
+        return response.Response(status=400, data=f"Invalid Parameters: {sql_err}")
     conn=connections["readonly"]
     with conn.cursor() as cur:
         cur.execute(sql)
         res = cur.fetchall()
     return response.Response(res)
+
+def get_bearer_token(request):
+    """
+    Expect: Authorization: Bearer <token>
+    """
+    auth = request.headers.get("Authorization", "")
+    if not auth:
+        return None
+    parts = auth.split(None, 1)  # ["Bearer", "<token>"]
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1].strip() or None
 
 def get_parameter(request, param):
     val = request.POST.get(param)
@@ -352,8 +363,10 @@ def get_parameter(request, param):
         err = f"No {param} parameter provided"
     return err, val
 
-def verify_token(token):
-    return token==environ["QUERY_SECRET_KEY"]
+def verify_token(request) -> bool:
+    token = get_bearer_token(request)
+    secret = environ.get("QUERY_SECRET_KEY", "")
+    return token==secret
 
 class FeatureViewSet(viewsets.ModelViewSet):
     """

--- a/web/settings.py
+++ b/web/settings.py
@@ -105,7 +105,7 @@ DATABASES = {
         "OPTIONS": {
             "options": "-c default_transaction_read_only=on",
         },
-    }
+    },
 }
 
 # Internationalization

--- a/web/settings.py
+++ b/web/settings.py
@@ -94,6 +94,17 @@ DATABASES = {
         "PASSWORD": os.environ["DB_PASS"],
         "HOST": os.environ["DB_SERVICE"],
         "PORT": os.environ["DB_PORT"],
+    },
+    "readonly": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "NAME": os.environ["DB_NAME"],
+        "USER": os.environ["DB_RO_USER"],
+        "PASSWORD": os.environ["DB_RO_PASS"],
+        "HOST": os.environ["DB_SERVICE"],
+        "PORT": os.environ["DB_PORT"],
+        "OPTIONS": {
+            "options": "-c default_transaction_read_only=on",
+        },
     }
 }
 


### PR DESCRIPTION
This PR adds an endpoint that allows trusted users to query the report database.

- It requires a token which will only be shared selectively
- It utilises a read only Postgres account
- The database connection is read only

To test (contact me for the token, it's on keeper):

Error on write:
```
curl -vk "https://reports.a.staging-mantidproject.stfc.ac.uk/api/query" \
  --data-urlencode "sql=INSERT INTO services_featureusage DEFAULT VALUES" --data-urlencode "token=<TOKEN>"
```

Read action:
```
curl -vk "https://reports.a.staging-mantidproject.stfc.ac.uk/api/query" \
  --data-urlencode "sql=SELECT * FROM services_featureusage LIMIT 10;" --data-urlencode "token=<TOKEN>" 
```

Closes #95